### PR TITLE
Adding local config to use .env in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,2 @@
 module.exports = require('@jupiterone/integration-sdk-dev-tools/config/jest');
 const path = require('path');
-require('dotenv').config({ path: path.resolve(__dirname, './.env') });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,1 +1,3 @@
 module.exports = require('@jupiterone/integration-sdk-dev-tools/config/jest');
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, './.env') });

--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
     "type-check": "tsc",
     "test": "jest",
+    "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration",
     "prepush": "yarn lint && yarn type-check && jest --changedSince master",
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0"
+    "@jupiterone/integration-sdk-core": "^6.0.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^5.11.0",
-    "@jupiterone/integration-sdk-dev-tools": "^5.11.0",
-    "@jupiterone/integration-sdk-testing": "^5.11.0"
+    "@jupiterone/integration-sdk-core": "^6.0.0",
+    "@jupiterone/integration-sdk-dev-tools": "^6.0.0",
+    "@jupiterone/integration-sdk-testing": "^6.0.0"
   }
 }

--- a/src/steps/index.test.ts
+++ b/src/steps/index.test.ts
@@ -3,14 +3,7 @@ import { createMockStepExecutionContext } from '@jupiterone/integration-sdk-test
 import { IntegrationConfig } from '../config';
 import { fetchGroups, fetchUsers } from './access';
 import { fetchAccountDetails } from './account';
-
-const DEFAULT_CLIENT_ID = 'dummy-acme-client-id';
-const DEFAULT_CLIENT_SECRET = 'dummy-acme-client-secret';
-
-const integrationConfig: IntegrationConfig = {
-  clientId: process.env.CLIENT_ID || DEFAULT_CLIENT_ID,
-  clientSecret: process.env.CLIENT_SECRET || DEFAULT_CLIENT_SECRET,
-};
+import { integrationConfig } from '../../test/config'; 
 
 test('should collect data', async () => {
   const context = createMockStepExecutionContext<IntegrationConfig>({

--- a/test/config.ts
+++ b/test/config.ts
@@ -1,0 +1,16 @@
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { IntegrationConfig } from '../src/config';
+
+if (process.env.LOAD_ENV) {
+  dotenv.config({
+    path: path.join(__dirname, '../.env'),
+  });
+}
+const DEFAULT_CLIENT_ID = 'dummy-acme-client-id';
+const DEFAULT_CLIENT_SECRET = 'dummy-acme-client-secret';
+
+export const integrationConfig: IntegrationConfig = {
+  clientId: process.env.CLIENT_ID || DEFAULT_CLIENT_ID,
+  clientSecret: process.env.CLIENT_SECRET || DEFAULT_CLIENT_SECRET,
+};


### PR DESCRIPTION
Hello @aiwilliams !

Per [Issue 29](https://github.com/JupiterOne/integration-template/issues/29), please find below the code to implement. Also updates template to version 6.0.0 of the SDK.

Kevin